### PR TITLE
Restore native HDR playback on YouTube 4.54.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # μTube
 
 MuTube enhances YouTube on Apple TV with [TizenTube Cobalt](https://github.com/reisxd/TizenTubeCobalt)'s userscript,
-which removes ads and adds support for features like SponsorBlock.
+which removes ads and adds support for features like SponsorBlock. This fork also restores Cobalt's native 4K HDR
+path for VP9 Profile 2 while leaving SDR formats and YouTube's original color metadata untouched.
 
 ## Setup
 
-MuTube has been tested with YouTube 4.54.01 on an Apple TV 4K.
+MuTube has been tested with YouTube 4.54.01 on an Apple TV 4K. Native patch addresses are specific to this exact
+YouTube version; the patcher validates the original ARM64 instructions and stops if they do not match.
 
 ### Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # μTube
 
 MuTube enhances YouTube on Apple TV with [TizenTube Cobalt](https://github.com/reisxd/TizenTubeCobalt)'s userscript,
-which removes ads and adds support for features like SponsorBlock. This fork also restores Cobalt's native 4K HDR
-path for VP9 Profile 2 while leaving SDR formats and YouTube's original color metadata untouched.
+which removes ads and adds support for features like SponsorBlock.
 
 ## Setup
 
-MuTube has been tested with YouTube 4.54.01 on an Apple TV 4K. Native patch addresses are specific to this exact
-YouTube version; the patcher validates the original ARM64 instructions and stops if they do not match.
+MuTube has been tested with YouTube 4.54.01 on an Apple TV 4K.
 
 ### Requirements
 

--- a/patcher.py
+++ b/patcher.py
@@ -45,6 +45,39 @@ PATCHES = [
     },
 ]
 
+COBALT_HOOKS = [
+    {
+        "name": "cobalt_vp9_profile2_support",
+        "kind": "media_support",
+        "entry_va": 0x101180894,
+        "expect": ("mov", "x20, x1"),
+    },
+]
+
+# YouTube 4.54.01 Cobalt gates used by the tvOS HDR output path. The patches
+# keep the app's existing AVDisplayCriteria and VP9 Profile 2 flow active after
+# the IPA is re-signed.
+COBALT_HDR_PATCHES = [
+    {
+        "name": "cobalt_display_criteria_gate",
+        "va": 0x101142BE4,
+        "expect": ("cbz", "w0, #0x101142d0c"),
+        "replacement": 0xD503201F,  # nop
+    },
+    {
+        "name": "cobalt_vp9_hdr_hw_gate",
+        "va": 0x10114F840,
+        "expect": ("cbz", "w0, #0x10114f874"),
+        "replacement": 0xD503201F,  # nop
+    },
+    {
+        "name": "cobalt_vp9_hdr_4k60_gate",
+        "va": 0x10114F870,
+        "expect": ("b", "#0x10114f730"),
+        "replacement": 0x14000009,  # b 0x10114f894 (supported)
+    },
+]
+
 MD = Cs(CS_ARCH_ARM64, CS_MODE_LITTLE_ENDIAN)
 MD.detail = False
 
@@ -314,6 +347,64 @@ def build_stub(kind, stub_va, addrs, orig_ins, enable_printf_logs):
             "blr x16",
             *emit_log(addrs, "log_csp_inject", include_ra=False, enabled=enable_printf_logs),
         ]
+    elif kind == "media_support":
+        # Re-signed builds can reject VP9 Profile 2 before YouTube exposes HDR
+        # formats. Report probable support only for Profile 2 MIME strings when
+        # AVPlayer confirms HDR playback eligibility. Missing APIs, SDR-only
+        # hardware, and every other codec fall through to Cobalt unchanged.
+        lines += [
+            "ldr x0, [sp]",
+            *load_addr("x1", addrs["vp9_profile2_full"]),
+            *load_addr("x16", addrs["strstr"]),
+            "blr x16",
+            "cbnz x0, media_profile2_check_hdr",
+            "ldr x0, [sp]",
+            *load_addr("x1", addrs["vp9_profile2_short"]),
+            *load_addr("x16", addrs["strstr"]),
+            "blr x16",
+            "cbz x0, media_profile2_continue",
+            "media_profile2_check_hdr:",
+            *load_addr("x0", addrs["avplayer_class_name"]),
+            *load_addr("x16", addrs["objc_get_class"]),
+            "blr x16",
+            "cbz x0, media_profile2_continue",
+            "mov x20, x0",
+            "movn x0, #1",
+            *load_addr("x1", addrs["sel_register_name_symbol"]),
+            *load_addr("x16", addrs["dlsym"]),
+            "blr x16",
+            "cbz x0, media_profile2_continue",
+            "mov x16, x0",
+            *load_addr("x0", addrs["hdr_eligible_selector"]),
+            "blr x16",
+            "cbz x0, media_profile2_continue",
+            "mov x21, x0",
+            "movn x0, #1",
+            *load_addr("x1", addrs["class_get_method_symbol"]),
+            *load_addr("x16", addrs["dlsym"]),
+            "blr x16",
+            "cbz x0, media_profile2_continue",
+            "mov x16, x0",
+            "mov x0, x20",
+            "mov x1, x21",
+            "blr x16",
+            "cbz x0, media_profile2_continue",
+            "mov x0, x20",
+            "mov x1, x21",
+            *load_addr("x16", addrs["objc_msg_send"]),
+            "blr x16",
+            "tbz w0, #0, media_profile2_continue",
+            "media_profile2_supported:",
+            *restore_regs(),
+            "mov w0, #2",
+            "ldp x29, x30, [sp, #0x130]",
+            "ldp x20, x19, [sp, #0x120]",
+            "ldp x22, x21, [sp, #0x110]",
+            "ldp x28, x27, [sp, #0x100]",
+            "add sp, sp, #0x140",
+            "ret",
+            "media_profile2_continue:",
+        ]
     else:
         raise ValueError(f"unknown stub kind: {kind}")
 
@@ -339,6 +430,12 @@ def patch_binary(data, enable_printf_logs=False):
         "yttv": put(YTTV_NEEDLE + b"\0"),
         "inject": put(js + b"\0"),
         "csp": put(CSP_PREFIX + b"\0"),
+        "vp9_profile2_full": put(b"vp09.02\0"),
+        "vp9_profile2_short": put(b"vp9.2\0"),
+        "avplayer_class_name": put(b"AVPlayer\0"),
+        "sel_register_name_symbol": put(b"sel_registerName\0"),
+        "class_get_method_symbol": put(b"class_getClassMethod\0"),
+        "hdr_eligible_selector": put(b"eligibleForHDRPlayback\0"),
     }
     if enable_printf_logs:
         offs |= {
@@ -357,13 +454,17 @@ def patch_binary(data, enable_printf_logs=False):
         "csp_len": len(CSP_PREFIX),
         "find": resolve_stub_va(info, "__ZNKSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE4findEPKcmm"),
         "insert": resolve_stub_va(info, "__ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6insertEmPKcm"),
+        "strstr": resolve_stub_va(info, "_strstr"),
+        "objc_get_class": resolve_stub_va(info, "_objc_getClass"),
+        "objc_msg_send": resolve_stub_va(info, "_objc_msgSend"),
+        "dlsym": resolve_stub_va(info, "_dlsym"),
     }
     if enable_printf_logs:
         addrs["printf"] = resolve_stub_va(info, "_printf")
 
     # Resolve final patch sites dynamically from function entry + prologue scan.
     resolved = []
-    for p in PATCHES:
+    for p in PATCHES + COBALT_HOOKS:
         site_va, site_off, orig_ins, insn = resolve_patch_site(data, info, p["entry_va"])
         if (insn.mnemonic, insn.op_str) != p["expect"]:
             raise ValueError(
@@ -395,6 +496,26 @@ def patch_binary(data, enable_printf_logs=False):
                 "patch_site_va": p["site_va"],
                 "stub_va": s["va"],
                 "stub_len": len(s["blob"]),
+            }
+        )
+
+    for patch in COBALT_HDR_PATCHES:
+        patch_off = va_to_off(info, patch["va"])
+        insn = disasm_one(data[patch_off:patch_off + 4], patch["va"])
+        if (insn.mnemonic, insn.op_str) != patch["expect"]:
+            raise ValueError(
+                f"{patch['name']}: at {hex(patch['va'])} expected "
+                f"{patch['expect'][0]} {patch['expect'][1]}, got "
+                f"{insn.mnemonic} {insn.op_str}"
+            )
+        data[patch_off:patch_off + 4] = struct.pack("<I", patch["replacement"])
+        out.append(
+            {
+                "name": patch["name"],
+                "entry_va": patch["va"],
+                "patch_site_va": patch["va"],
+                "stub_va": 0,
+                "stub_len": 0,
             }
         )
 

--- a/patcher.py
+++ b/patcher.py
@@ -354,6 +354,7 @@ def build_stub(kind, stub_va, addrs, orig_ins, enable_printf_logs):
         # hardware, and every other codec fall through to Cobalt unchanged.
         lines += [
             "ldr x0, [sp]",
+            "cbz x0, media_profile2_continue",
             *load_addr("x1", addrs["vp9_profile2_full"]),
             *load_addr("x16", addrs["strstr"]),
             "blr x16",


### PR DESCRIPTION
## Summary

This PR restores native 4K HDR playback on Apple TV for re-signed YouTube 4.54.01 builds, while preserving 4K SDR playback and the original quality selection.

## Root cause

After re-signing the application, Cobalt rejects VP9 Profile 2 capability checks and does not complete the existing tvOS display criteria path. As a result, HDR formats are either hidden or decoded without switching the television to HDR output.

## Changes

- Report probable Cobalt support only for VP9 Profile 2 MIME types (`vp09.02` and `vp9.2`).
- Keep the existing `AVDisplayCriteria` HDR output path enabled.
- Enable Cobalt's VP9 HDR hardware and 4K60 support paths.
- Validate the original ARM64 instructions before applying version-specific patches.

## Tested

Tested with YouTube 4.54.01 on Apple TV 4K 3rd gen:

- 2160p HDR VP9 Profile 2 playback works.
- The television correctly switches to HDR mode.
- 4K SDR playback remains available.
- Lower resolutions and manual quality selection remain available.
- No diagnostic overlay is displayed.

## Test build

A ready-built version is available here:

https://drive.google.com/file/d/1Svqu_5PlgojhsLBTibyc1s6EYHOEc8-e/view?usp=share_link

## Compatibility

The native offsets are specific to YouTube 4.54.01. The patcher fails safely when the expected ARM64 instructions do not match.

Closes #2.